### PR TITLE
BugFix: Dissonance Curve Number of Points Issue

### DIFF
--- a/src/xentonality/dissonance.ts
+++ b/src/xentonality/dissonance.ts
@@ -48,7 +48,7 @@ export const calcDissonanceCurve = (partials: TPartials, points?: number): TDiss
         cents: 1200,
     }
 
-    const numberOfPoints = points ? points : pseudoOctave.cents + 1
+    const numberOfPoints = points ? points : Math.round(pseudoOctave.cents) + 1
     const sweepStep = { cents: points ? pseudoOctave.cents / (points - 1) : 1 }
 
 


### PR DESCRIPTION
Sometimes because of machine epsilon numberOfPoints in diss-curve calculation had a float value. As a quick patch added rounding of it. Rounding of all my function returns will handle later.