### PR TITLE
Generated EDO spectrum has no partials with same frequency

### DIFF
--- a/src/xentonality/dissonance.ts
+++ b/src/xentonality/dissonance.ts
@@ -3,9 +3,8 @@ import { centsToRatio, detrend, normalize, ratioToCents } from "./utils"
 import type { TDissonanceCurve, TPartials, TPlotCurve, TPlotPoint, TPointX } from "./types"
 
 
-export const plompLeveltDissonance = ({ minLoudness, frequencyDifference, minFrequency }: { minLoudness: number, frequencyDifference: number, minFrequency: number }): number => {
-    if (minLoudness === 0 || minFrequency === 0) return 0
-
+export const plompLeveltDissonance = ({ minLoudness, frequencyDifference, minFrequency, }: { minLoudness: number, frequencyDifference: number, minFrequency: number }): number => {
+    if (minLoudness === 0 || minFrequency === 0 || frequencyDifference === 0) return 0
     const coefficient = frequencyDifference / (0.021 * minFrequency + 19)
 
     return minLoudness * (Math.exp(-0.84 * coefficient) - Math.exp(-1.38 * coefficient))
@@ -36,17 +35,17 @@ export const calcDissonanceCurve = (partials: TPartials, points?: number): TDiss
     const dissonanceCurve = [] as TPlotCurve
     const fundamental = partials[0].frequency
 
-    const pseudoOctave = partials.length > 1 
-    ? {
-        ratio: partials[1].ratio,
-        Hz: partials[1].frequency - fundamental,
-        cents: ratioToCents(partials[1].ratio),
-    }
-    : {
-        ratio: 2,
-        Hz: fundamental,
-        cents: 1200,
-    }
+    const pseudoOctave = partials.length > 1
+        ? {
+            ratio: partials[1].ratio,
+            Hz: partials[1].frequency - fundamental,
+            cents: ratioToCents(partials[1].ratio),
+        }
+        : {
+            ratio: 2,
+            Hz: fundamental,
+            cents: 1200,
+        }
 
     const numberOfPoints = points ? points : Math.round(pseudoOctave.cents) + 1
     const sweepStep = { cents: points ? pseudoOctave.cents / (points - 1) : 1 }

--- a/src/xentonality/spectrum.ts
+++ b/src/xentonality/spectrum.ts
@@ -2,7 +2,7 @@ import type { TPartials, TSpectrumType } from "./types"
 import { centsToRatio, checkNumericParam, getAmplitude, setharesLoudness } from "./utils"
 import { cloneDeep, round } from 'lodash-es'
 
-export const generatePartials = ({ type, profile = 'harmonic', pseudoOctave = 1200, edo = 12, fundamental = 440, number = 1000 }: { type: TSpectrumType, profile?: 'equal' | 'harmonic', pseudoOctave?: number, edo?: number, fundamental?: number, number?: number }): TPartials => {
+export const generatePartials = ({ type, profile = 'harmonic', pseudoOctave = 1200, edo = 12, fundamental = 440, number = 100 }: { type: TSpectrumType, profile?: 'equal' | 'harmonic', pseudoOctave?: number, edo?: number, fundamental?: number, number?: number }): TPartials => {
     const partials = [] as TPartials
 
     const success = checkNumericParam({ param: number, condition: number > 0, integer: true }) && checkNumericParam({ param: fundamental, condition: fundamental > 0 })
@@ -12,7 +12,6 @@ export const generatePartials = ({ type, profile = 'harmonic', pseudoOctave = 12
         return partials
     }
 
-    // TODO: untested with pseudoOctave
     if (type === 'harmonic') {
         for (let i = 1; i <= number; i++) {
             const amplitude = getAmplitude(profile, i)
@@ -22,16 +21,18 @@ export const generatePartials = ({ type, profile = 'harmonic', pseudoOctave = 12
         }
     }
 
-    // TODO: untested
     if (type === 'edo') {
-        for (let i = 1; i <= number; i++) {
-            const amplitude = getAmplitude(profile, i)
-            const frequency = fundamental * (pseudoOctaveRatio ** (Math.round(Math.log2(i) * edo) / edo))
-            const ratio = frequency / fundamental
-            partials.push({ ratio: ratio, frequency: frequency, amplitude: amplitude, loudness: setharesLoudness(amplitude) })
+        let iteration = 1
+        while (partials.length < number) {
+            const frequency = fundamental * (pseudoOctaveRatio ** (Math.round(Math.log2(iteration) * edo) / edo))
+            if (frequency !== partials[partials.length - 1]?.frequency) {
+                const ratio = frequency / fundamental
+                const amplitude = getAmplitude(profile, ratio)
+                partials.push({ ratio: ratio, frequency: frequency, amplitude: amplitude, loudness: setharesLoudness(amplitude) })
+            }
+            iteration++
         }
     }
-
 
     return partials
 }
@@ -56,19 +57,29 @@ export const changeFundamental = ({ partials, fundamental }: { partials: TPartia
 
 
 
-export const sumPartials = (...args: TPartials[]): TPartials => {
+export const sumPartials = (...spectrums: TPartials[]): TPartials => {
     const result = [] as TPartials
-    const partialGroups = cloneDeep(args) as TPartials[]
-    const allPartials = partialGroups.flatMap(partialGroup => partialGroup).sort((a, b) => a.frequency - b.frequency) as TPartials
+    const partials = cloneDeep(spectrums)
+    const allPartials = partials.flat().sort((a, b) => a.frequency - b.frequency) as TPartials
 
-    for (let i = 0; i < allPartials.length; i++) {
+    if (allPartials.length === 0) {
+        return result
+    }
+
+    result[0] = allPartials[0]
+    const fundamental = result[0].frequency
+
+    for (let i = 1; i < allPartials.length; i++) {
         if (result[result.length - 1] && allPartials[i].frequency === result[result.length - 1].frequency) {
+            const summedAmplitude = result[result.length - 1].amplitude + allPartials[i].amplitude
 
-            result[result.length - 1].amplitude += allPartials[i].amplitude
-            result[result.length - 1].loudness = setharesLoudness(result[result.length - 1].amplitude)
-
+            result[result.length - 1].amplitude = summedAmplitude
+            result[result.length - 1].loudness = setharesLoudness(summedAmplitude)
         } else {
-            result.push({ ...allPartials[i], ratio: i === 0 ? allPartials[i].ratio : allPartials[i].frequency / result[0].frequency })
+            result.push({
+                ...allPartials[i],
+                ratio: allPartials[i].frequency / fundamental,
+            })
         }
     }
 
@@ -76,14 +87,25 @@ export const sumPartials = (...args: TPartials[]): TPartials => {
 }
 
 
-// TODO: untested
-export const combinePartials = (...args: TPartials[]): TPartials => {
-    const result = [] as TPartials
-    const partialGroups = cloneDeep(args) as TPartials[]
-    const allPartials = partialGroups.flatMap(partialGroup => partialGroup).sort((a, b) => a.frequency - b.frequency) as TPartials
 
-    for (let i = 0; i < allPartials.length; i++) {
-        result.push({ ...allPartials[i], ratio: i === 0 ? allPartials[i].ratio : allPartials[i].frequency / result[0].frequency })
+export const combinePartials = (...spectrums: TPartials[]): TPartials => {
+    const result = [] as TPartials
+    const partials = cloneDeep(spectrums)
+    const allPartials = partials.flat().sort((a, b) => a.frequency - b.frequency) as TPartials
+
+    if (allPartials.length === 0) {
+        return result
+    }
+
+    result[0] = allPartials[0]
+    const fundamental = result[0].frequency
+
+    for (let i = 1; i < allPartials.length; i++) {
+
+        result[i] = {
+            ...allPartials[i],
+            ratio: allPartials[i].frequency / fundamental,
+        }
     }
 
     return result

--- a/src/xentonality/utils.ts
+++ b/src/xentonality/utils.ts
@@ -1,24 +1,26 @@
 import type { TPartials, TPlotCurve } from "./types"
 import { round } from 'lodash-es';
 
-// TODO: Untested
+
 export const ratioToCents = (ratio: number): number => {
-    return 1200 * Math.log2(ratio)
+    return ratio > 0 ? 1200 * Math.log2(ratio) : 0
 }
-// TODO: Untested
+
+
 export const centsToRatio = (cents: number): number => {
     return 2 ** (cents / 1200)
 }
 
+// rethink error handling
 export const checkNumericParam = ({ param, integer = false, condition }: { param: number, integer?: boolean, condition?: boolean }): boolean => {
     let success = true
 
     if (integer && param.toFixed(0) !== param.toString()) {
-        console.warn(`ParamNotInteger: In checkNumericParam, param has value ${param}, while integer flag is ${integer}! Success = false`)
+        console.error(`ParamNotInteger: In checkNumericParam, param has value ${param}, while integer flag is ${integer}! Success = false`)
         success = false
     }
     if (!condition) {
-        console.warn(`ConditionViolation: In checkNumericParam, param value ${param} do not satisfy provided condition! Success = false`)
+        console.error(`ConditionViolation: In checkNumericParam, param value ${param} do not satisfy provided condition! Success = false`)
         success = false
     }
 
@@ -26,16 +28,16 @@ export const checkNumericParam = ({ param, integer = false, condition }: { param
 }
 
 
-
+// rethink error handling
 export const checkPartials = ({ partials, freqCondition, ampCondition }: { partials: TPartials, freqCondition?: (frequency: number) => boolean, ampCondition?: (amplitude: number) => boolean }): boolean => {
     let success = true
 
     if (ampCondition && partials.every(({ amplitude }) => ampCondition(amplitude))) {
-        console.warn(`AmplitudeConditionNotSatisfied: In checkSpectrum, one of the amplitudes did not satisfy provided condition! Success = false`)
+        console.error(`AmplitudeConditionNotSatisfied: In checkSpectrum, one of the amplitudes did not satisfy provided condition! Success = false`)
         success = false
     }
     if (freqCondition && partials.every(({ frequency }) => freqCondition(frequency))) {
-        console.warn(`FrequencyConditionNotSatisfied: In checkSpectrum, one of the frequencies did not satisfy provided condition! Success = false`)
+        console.error(`FrequencyConditionNotSatisfied: In checkSpectrum, one of the frequencies did not satisfy provided condition! Success = false`)
         success = false
     }
 
@@ -45,11 +47,7 @@ export const checkPartials = ({ partials, freqCondition, ampCondition }: { parti
 
 
 export const getAmplitude = (profile: 'equal' | 'harmonic', ratio: number) => {
-    if (profile === "equal") {
-        return ratio >= 1 ? 1 : 0
-    }
-
-    return ratio >= 1 ? 1 / ratio : 0 // --> defaults to harmonic profile
+    return ratio < 1 ? 0 : profile === "harmonic" ? 1 / ratio : 1
 }
 
 
@@ -57,7 +55,7 @@ export const getAmplitude = (profile: 'equal' | 'harmonic', ratio: number) => {
 export const setharesLoudness = (amplitude: number): number => 0.25 * 2 ** Math.log10(2E8 * amplitude)
 
 
-
+ 
 export const detrend = (curve: TPlotCurve): TPlotCurve => {
     const result = [] as TPlotCurve
 

--- a/test/unit/factories.ts
+++ b/test/unit/factories.ts
@@ -16,7 +16,16 @@ const getZeroPlot = (): TPlotCurve => {
 
 
 // Partials
-export const partials = ({ ratios = [1, 2, 3, 4], fundamental = 440, amplitude }: { ratios?: number[], fundamental?: number, amplitude?: number }) => ratios.map(ratio => { return { ratio: ratio, frequency: ratio * fundamental, amplitude: amplitude === undefined ? 1 / ratio : amplitude, loudness: setharesLoudness(amplitude === undefined ? 1 / ratio : amplitude) } }) as TPartials
+export const partials = ({ ratios = [], fundamental = 440, amplitude  }: { ratios?: number[], fundamental?: number, amplitude?: number, }) => (
+    ratios.map((ratio, index) => {
+        return {
+            ratio: ratio,
+            frequency: ratio * fundamental,
+            amplitude: amplitude === undefined ? 1 / (index + 1) : amplitude,
+            loudness: setharesLoudness(amplitude === undefined ? 1 / (index + 1) : amplitude)
+        }
+    }) as TPartials
+)
 
 export const noPartals = partials({ ratios: [] })
 

--- a/test/unit/fixtures/spectrum.ts
+++ b/test/unit/fixtures/spectrum.ts
@@ -1,0 +1,176 @@
+export const edo12_1200PseudoOct_harmonicAmpProfile = [
+    {
+        ratio: 1,
+        frequency: 440,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 2,
+        frequency: 880,
+        amplitude: 0.5,
+        loudness: 64
+    },
+    {
+        ratio: 2.996614153753363,
+        frequency: 1318.5102276514797,
+        amplitude: 0.3337099635425086,
+        loudness: 56.66551714975867
+    },
+    {
+        ratio: 4,
+        frequency: 1760,
+        amplitude: 0.25,
+        loudness: 51.94705311884243
+    },
+    {
+        ratio: 5.039684199579494,
+        frequency: 2217.461047814977,
+        amplitude: 0.1984251314960249,
+        loudness: 48.45678127868751
+    },
+    {
+        ratio: 5.993228307506726,
+        frequency: 2637.0204553029594,
+        amplitude: 0.1668549817712543,
+        loudness: 45.99385358414361
+    },
+    {
+        ratio: 7.127189745122715,
+        frequency: 3135.9634878539946,
+        amplitude: 0.1403077560386716,
+        loudness: 43.656109871459
+    },
+    {
+        ratio: 8,
+        frequency: 3520,
+        amplitude: 0.125,
+        loudness: 42.16400512080996
+    },
+    {
+        ratio: 8.979696386474982,
+        frequency: 3951.066410048992,
+        amplitude: 0.11136233976754244,
+        loudness: 40.72289842274657
+    },
+    {
+        ratio: 10.079368399158987,
+        frequency: 4434.922095629954,
+        amplitude: 0.09921256574801245,
+        loudness: 39.33104673518921
+    }
+]
+
+export const edo7_fund100_2400PseudoOct_equalAmpProfile = [
+    {
+        ratio: 1,
+        frequency: 100,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 4,
+        frequency: 400,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 8.832716109390498,
+        frequency: 883.2716109390498,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 16,
+        frequency: 1600,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 23.77590862619117,
+        frequency: 2377.590862619117,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 35.330864437562006,
+        frequency: 3533.0864437562004,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 52.50146278448884,
+        frequency: 5250.146278448884,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 64,
+        frequency: 6400,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 78.01687386908642,
+        frequency: 7801.687386908642,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 95.10363450476468,
+        frequency: 9510.363450476469,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    }
+]
+
+export const edo3_fund100_harmAmpProfile = [
+    {
+        ratio: 1,
+        frequency: 100,
+        amplitude: 1,
+        loudness: 78.84951607609639
+    },
+    {
+        ratio: 2,
+        frequency: 200,
+        amplitude: 0.5,
+        loudness: 64
+    },
+    {
+        ratio: 3.174802103936399,
+        frequency: 317.48021039363994,
+        amplitude: 0.31498026247371824,
+        loudness: 55.68872418933659
+    },
+    {
+        ratio: 4,
+        frequency: 400,
+        amplitude: 0.25,
+        loudness: 51.94705311884243
+    },
+    {
+        ratio: 5.039684199579494,
+        frequency: 503.9684199579494,
+        amplitude: 0.1984251314960249,
+        loudness: 48.45678127868751
+    },
+    {
+        ratio: 6.3496042078727974,
+        frequency: 634.9604207872798,
+        amplitude: 0.15749013123685915,
+        loudness: 45.201017399750526
+    },
+    {
+        ratio: 8,
+        frequency: 800,
+        amplitude: 0.125,
+        loudness: 42.16400512080996
+    },
+    {
+        ratio: 10.079368399158987,
+        frequency: 1007.9368399158988,
+        amplitude: 0.09921256574801245,
+        loudness: 39.33104673518921
+    }
+]

--- a/test/unit/xentonality.dissonance.test.ts
+++ b/test/unit/xentonality.dissonance.test.ts
@@ -48,13 +48,12 @@ describe('Xentonality.Dissonance.intrinsicDissonance', () => {
 
     // WARNING: value not tested, taken from result of function
     it('returns correct value for complex spectrum', () => {
-        expect(Dissonance.intrinsicDissonance(Factory.partials({}))).toEqual(0.02201318145631032);
+        expect(Dissonance.intrinsicDissonance(Factory.partials({ ratios: [1, 2, 3, 4] }))).toEqual(0.02201318145631032);
     });
 })
 
 describe('Xentonality.Dissonance.calcDissonanceCurve', () => {
     // WARNING: I assume fixtures are correct, but need manual testing to confirm that
-    // WARNING: check default number of points for diss curve 
     it('returns diss curve for single partial', () => {
         const testFunction = Dissonance.calcDissonanceCurve(Factory.partials({ ratios: [1], fundamental: 440 }), 10).curve
         const expectedFunction = diss_curve_440_1_partial
@@ -67,6 +66,15 @@ describe('Xentonality.Dissonance.calcDissonanceCurve', () => {
         const expectedFunction = diss_curve_440_4_harmonic
 
         expect(curvesEqual(testFunction, expectedFunction)).toEqual(true);
+    })
+
+    it('returns diss curve with default number of points = cents in pseudo-octave', () => {
+        const dissCurve = Dissonance.calcDissonanceCurve(Factory.partials({ ratios: [1, 2.1], fundamental: 440 })).curve
+        const expectedStepInCents = 1
+        const expectedNumberOfPoints = 1285
+
+        expect(dissCurve[1].cents - dissCurve[0].cents).toEqual(expectedStepInCents);
+        expect(dissCurve.length).toEqual(expectedNumberOfPoints);
     })
 
     it('returns diss curve within the range of pseudo-octave with correct step', () => {

--- a/test/unit/xentonality.spectrum.test.ts
+++ b/test/unit/xentonality.spectrum.test.ts
@@ -1,10 +1,32 @@
+import { sum } from 'lodash';
 import * as Spectrum from '../../src/xentonality/spectrum';
 import * as Factory from './factories'
+import * as Fixture from './fixtures/spectrum'
 
 
 describe('Xentonality.Spectrum.generatePartials', () => {
+  it('returns default value of 1000 partials', () => {
+    const partials = Spectrum.generatePartials({ type: 'harmonic' })
+    expect(partials.length).toEqual(100);
+  });
+
+  it('returns empty partials if number = 0', () => {
+    const expectedOutcome = Factory.noPartals
+    expect(Spectrum.generatePartials({ type: 'harmonic', number: 0 })).toEqual(expectedOutcome);
+  });
+
+  it('returns empty array of partials if number < 0', () => {
+    const expectedOutcome = Factory.noPartals
+    expect(Spectrum.generatePartials({ type: 'harmonic', number: -1 })).toEqual(expectedOutcome);
+  });
+
+  it('returns empty array of partials if number is not integer', () => {
+    const expectedOutcome = Factory.noPartals
+    expect(Spectrum.generatePartials({ type: 'harmonic', number: 2.5 })).toEqual(expectedOutcome);
+  });
+
   it('returns 4 harmonic partials with harmonic amplitude profile', () => {
-    const expectedOutcome = Factory.partials({})
+    const expectedOutcome = Factory.partials({ ratios: [1, 2, 3, 4] })
     expect(Spectrum.generatePartials({ type: 'harmonic', number: 4 })).toEqual(expectedOutcome);
   });
 
@@ -18,24 +40,24 @@ describe('Xentonality.Spectrum.generatePartials', () => {
     expect(Spectrum.generatePartials({ type: 'harmonic', fundamental: 100, number: 4 })[0].frequency).toEqual(expectedOutcome);
   });
 
-  it('returns default value of 1000 partials', () => {
-    const partials = Spectrum.generatePartials({ type: 'harmonic' })
-    expect(partials.length).toEqual(1000);
+  it('returns 3 partials of stretched spectrum with pseudoOctave of 2400 and harmonic amplitude profile', () => {
+    const expectedOutcome = Factory.partials({ ratios: [1, 4, 9] })
+    expect(Spectrum.generatePartials({ type: 'harmonic', number: 3, pseudoOctave: 2400 })).toEqual(expectedOutcome);
   });
 
-  it('returns empty partials if number = 0', () => {
-    const expectedOutcome = Factory.noPartals
-    expect(Spectrum.generatePartials({ type: 'harmonic', number: 0 })).toEqual(expectedOutcome);
+  it('returns 10 partials of default 12 edo spectrum and harmonic amplitude profile', () => {
+    const expectedOutcome = Fixture.edo12_1200PseudoOct_harmonicAmpProfile
+    expect(Spectrum.generatePartials({ type: 'edo', number: 10 })).toEqual(expectedOutcome);
   });
 
-  it('returns empty partials if number < 0', () => {
-    const expectedOutcome = Factory.noPartals
-    expect(Spectrum.generatePartials({ type: 'harmonic', number: -1 })).toEqual(expectedOutcome);
+  it('returns 10 partials of 7 edo spectrum and equal amplitude profile', () => {
+    const expectedOutcome = Fixture.edo7_fund100_2400PseudoOct_equalAmpProfile
+    expect(Spectrum.generatePartials({ type: 'edo', fundamental: 100, edo: 7, number: 10, profile: 'equal', pseudoOctave: 2400 })).toEqual(expectedOutcome);
   });
 
-  it('returns empty partials if number is not integer', () => {
-    const expectedOutcome = Factory.noPartals
-    expect(Spectrum.generatePartials({ type: 'harmonic', number: 2.5 })).toEqual(expectedOutcome);
+  it('returns 8 partials of 3 edo spectrum with no duplicates and harmonic amplitude profile', () => {
+    const expectedOutcome = Fixture.edo3_fund100_harmAmpProfile
+    expect(Spectrum.generatePartials({ type: 'edo', edo: 3, number: 8, fundamental: 100 })).toEqual(expectedOutcome);
   });
 })
 
@@ -43,15 +65,15 @@ describe('Xentonality.Spectrum.generatePartials', () => {
 
 describe('Xentonality.Spectrum.changeFundamental', () => {
   it('recalculates all the partials frequencies with new provided fundamental and does not change input spectrum', () => {
-    const partials = Factory.partials({})
+    const partials = Factory.partials({ ratios: [1, 2, 3, 4] })
 
-    const expectedOutcome = Factory.partials({ fundamental: 432 })
+    const expectedOutcome = Factory.partials({ ratios: [1, 2, 3, 4], fundamental: 432 })
     expect(Spectrum.changeFundamental({ partials: partials, fundamental: 432 })).toEqual(expectedOutcome);
-    expect(partials).toEqual(Factory.partials({}));
+    expect(partials).toEqual(Factory.partials({ ratios: [1, 2, 3, 4] }));
   });
 
   it('returns 0 partials if provided fundamental < 0', () => {
-    const partials = Factory.partials({})
+    const partials = Factory.partials({ ratios: [1, 2, 3, 4] })
 
     const expectedOutcome = Factory.noPartals
     expect(Spectrum.changeFundamental({ partials: partials, fundamental: -440 })).toEqual(expectedOutcome);
@@ -70,23 +92,32 @@ describe('Xentonality.Spectrum.sumPartials', () => {
   });
 
   it('combines non-overlaping spectrums sorted by increasing freq and doesnt change input spectrums', () => {
-    const spectrum1 = Factory.partials({ ratios: [5, 6, 7, 8] })
-    const spectrum2 = Factory.partials({})
-    const spectrum3 = Factory.partials({ ratios: [10, 20, 30, 40] })
-    const combined = Spectrum.sumPartials(spectrum1, spectrum2, spectrum3)
+    const spectrum1 = Factory.partials({ ratios: [5, 6] })
+    const spectrum2 = Factory.partials({ ratios: [1, 2] })
+    const spectrum3 = Factory.partials({ ratios: [10, 20] })
+    const summed = Spectrum.sumPartials(spectrum1, spectrum2, spectrum3)
 
-    const expectedOutcome = Factory.partials({ ratios: [1, 2, 3, 4, 5, 6, 7, 8, 10, 20, 30, 40] })
+    const expectedOutcome = [
+      { ratio: 1, frequency: 440, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 2, frequency: 880, amplitude: 0.5, loudness: 64 },
+      { ratio: 5, frequency: 2200, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 6, frequency: 2640, amplitude: 0.5, loudness: 64 },
+      { ratio: 10, frequency: 4400, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 20, frequency: 8800, amplitude: 0.5, loudness: 64 }
+    ]
 
-    expect(spectrum1).toEqual(Factory.partials({ ratios: [5, 6, 7, 8] }));
-    expect(spectrum3).toEqual(Factory.partials({ ratios: [10, 20, 30, 40] }));
-    expect(combined).toEqual(expectedOutcome);
+    expect(spectrum1).toEqual(Factory.partials({ ratios: [5, 6] }));
+    expect(spectrum2).toEqual(Factory.partials({ ratios: [1, 2] }));
+    expect(spectrum3).toEqual(Factory.partials({ ratios: [10, 20] }));
+    expect(summed.length).toEqual(6)
+    expect(summed).toEqual(expectedOutcome);
   });
 
   it('combines close overlaping spectrums, sums overlaping amplitudes and doesnt change input spectrums', () => {
     const spectrum1 = Factory.partials({ ratios: [1, 2] })
     const spectrum2 = Factory.partials({ ratios: [1, 2], fundamental: 440.01 })
     const spectrumOverlap = Factory.partials({ ratios: [1], fundamental: 880 })
-    const combined = Spectrum.sumPartials(spectrum1, spectrum2, spectrumOverlap)
+    const summed = Spectrum.sumPartials(spectrum1, spectrum2, spectrumOverlap)
 
     const expectedOutcome = [
       { ratio: 1, frequency: 440, amplitude: 1, loudness: 78.84951607609639 },
@@ -97,19 +128,100 @@ describe('Xentonality.Spectrum.sumPartials', () => {
 
     expect(spectrum1).toEqual(Factory.partials({ ratios: [1, 2] }));
     expect(spectrum2).toEqual(Factory.partials({ ratios: [1, 2], fundamental: 440.01 }));
+    expect(summed).toEqual(expectedOutcome);
+  });
+
+  it('sums amplitudes of equal spectrums and doesnt change input spectrums', () => {
+    const spectrum1 = Factory.partials({ ratios: [1, 2, 3, 4], amplitude: 1 })
+    const spectrum2 = Factory.partials({ ratios: [1, 2, 3, 4], amplitude: 1 })
+    const spectrum3 = Factory.partials({ ratios: [1, 2, 3, 4], amplitude: 1 })
+    const summed = Spectrum.sumPartials(spectrum1, spectrum2, spectrum3)
+
+    const expectedOutcome = [
+      { ratio: 1, frequency: 440, amplitude: 3, loudness: 109.75563873295522 },
+      { ratio: 2, frequency: 880, amplitude: 3, loudness: 109.75563873295522 },
+      { ratio: 3, frequency: 1320, amplitude: 3, loudness: 109.75563873295522 },
+      { ratio: 4, frequency: 1760, amplitude: 3, loudness: 109.75563873295522 }
+    ]
+
+    expect(spectrum1).toEqual(Factory.partials({ ratios: [1, 2, 3, 4], amplitude: 1 }));
+    expect(spectrum2).toEqual(Factory.partials({ ratios: [1, 2, 3, 4], amplitude: 1 }));
+    expect(spectrum3).toEqual(Factory.partials({ ratios: [1, 2, 3, 4], amplitude: 1 }));
+    expect(summed.length).toEqual(4);
+    expect(summed).toEqual(expectedOutcome);
+  });
+})
+
+
+
+describe('Xentonality.Spectrum.combinePartials', () => {
+  it('returns empty spectrum if empty spectrums are provided', () => {
+    expect(Spectrum.combinePartials(Factory.noPartals, Factory.noPartals)).toEqual(Factory.noPartals);
+  });
+
+  it('combines non-overlaping spectrums sorted by increasing freq and doesnt change input spectrums', () => {
+    const spectrum1 = Factory.partials({ ratios: [5, 6] })
+    const spectrum2 = Factory.partials({ ratios: [1, 2] })
+    const spectrum3 = Factory.partials({ ratios: [10, 20] })
+    const combined = Spectrum.combinePartials(spectrum1, spectrum2, spectrum3)
+
+    const expectedOutcome = [
+      { ratio: 1, frequency: 440, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 2, frequency: 880, amplitude: 0.5, loudness: 64 },
+      { ratio: 5, frequency: 2200, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 6, frequency: 2640, amplitude: 0.5, loudness: 64 },
+      { ratio: 10, frequency: 4400, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 20, frequency: 8800, amplitude: 0.5, loudness: 64 },
+    ]
+
+    expect(spectrum1).toEqual(Factory.partials({ ratios: [5, 6] }));
+    expect(spectrum2).toEqual(Factory.partials({ ratios: [1, 2] }));
+    expect(spectrum3).toEqual(Factory.partials({ ratios: [10, 20] }));
+    expect(combined).toEqual(expectedOutcome);
+  });
+
+  it('combines close overlaping spectrums, sums overlaping amplitudes and doesnt change input spectrums', () => {
+    const spectrum1 = Factory.partials({ ratios: [1, 2] })
+    const spectrum2 = Factory.partials({ ratios: [1, 2], fundamental: 440.01 })
+    const spectrumOverlap = Factory.partials({ ratios: [1], fundamental: 880 })
+    const combined = Spectrum.combinePartials(spectrum1, spectrum2, spectrumOverlap)
+
+    const expectedOutcome = [
+      { ratio: 1, frequency: 440, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 1.0000227272727273, frequency: 440.01, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 2, frequency: 880, amplitude: 0.5, loudness: 64 },
+      { ratio: 2, frequency: 880, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 2.0000454545454547, frequency: 880.02, amplitude: 0.5, loudness: 64 },
+    ]
+
+    expect(spectrum1).toEqual(Factory.partials({ ratios: [1, 2] }));
+    expect(spectrum2).toEqual(Factory.partials({ ratios: [1, 2], fundamental: 440.01 }));
+    expect(combined.length).toEqual(5)
     expect(combined).toEqual(expectedOutcome);
   });
 
   it('sums amplitudes of equal spectrums and doesnt change input spectrums', () => {
-    const spectrum1 = Factory.partials({ amplitude: 1 })
-    const spectrum2 = Factory.partials({ amplitude: 1 })
-    const spectrum3 = Factory.partials({ amplitude: 1 })
-    const combined = Spectrum.sumPartials(spectrum1, spectrum2, spectrum3)
+    const spectrum1 = Factory.partials({ ratios: [1, 2, 3], amplitude: 1 })
+    const spectrum2 = Factory.partials({ ratios: [1, 2, 3], amplitude: 1 })
+    const spectrum3 = Factory.partials({ ratios: [1, 2, 3], amplitude: 1 })
+    const combined = Spectrum.combinePartials(spectrum1, spectrum2, spectrum3)
 
-    const expectedOutcome = Factory.partials({ amplitude: 3 })
+    const expectedOutcome = [
+      { ratio: 1, frequency: 440, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 1, frequency: 440, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 1, frequency: 440, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 2, frequency: 880, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 2, frequency: 880, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 2, frequency: 880, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 3, frequency: 1320, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 3, frequency: 1320, amplitude: 1, loudness: 78.84951607609639 },
+      { ratio: 3, frequency: 1320, amplitude: 1, loudness: 78.84951607609639 },
+    ]
 
-    expect(spectrum1).toEqual(Factory.partials({ amplitude: 1 }));
-    expect(spectrum2).toEqual(Factory.partials({ amplitude: 1 }));
+    expect(spectrum1).toEqual(Factory.partials({ ratios: [1, 2, 3], amplitude: 1 }));
+    expect(spectrum2).toEqual(Factory.partials({ ratios: [1, 2, 3], amplitude: 1 }));
+    expect(spectrum3).toEqual(Factory.partials({ ratios: [1, 2, 3], amplitude: 1 }));
+    expect(combined.length).toEqual(9);
     expect(combined).toEqual(expectedOutcome);
   });
 })

--- a/test/unit/xentonality.utils.test.ts
+++ b/test/unit/xentonality.utils.test.ts
@@ -3,13 +3,60 @@ import * as Factory from "./factories"
 import { curvesEqual } from "./assertions"
 
 
+describe('Xentonality.Utils.ratioToCents', () => {
+    it('returns 0 if provided ratio is 1', () => {
+        expect(Utils.ratioToCents(1)).toEqual(0);
+    });
+
+    it('returns -1200 if provided ratio is 0.5', () => {
+        expect(Utils.ratioToCents(0.5)).toEqual(-1200);
+    });
+
+    it('returns 386.3137138648348 if 5 / 4 ratio is provided', () => {
+        expect(Utils.ratioToCents(5 / 4)).toEqual(386.3137138648348);
+    });
+
+    it('returns 1200 if ratio 2 is provided', () => {
+        expect(Utils.ratioToCents(2)).toEqual(1200);
+    });
+
+    it('returns 0 if provided ratio is 0', () => {
+        expect(Utils.ratioToCents(0)).toEqual(0);
+    });
+
+    it('returns 0 if provided ratio is < 0', () => {
+        expect(Utils.ratioToCents(-1)).toEqual(0);
+    });
+})
+
+
+describe('Xentonality.Utils.centsToRatio', () => {
+    it('returns 1 if 0 is provided', () => {
+        expect(Utils.centsToRatio(0)).toEqual(1);
+    });
+
+    it('returns 2 if 1200 is provided', () => {
+        expect(Utils.centsToRatio(1200)).toEqual(2);
+    });
+
+    it('returns 0.5 if -1200 is provided', () => {
+        expect(Utils.centsToRatio(-1200)).toEqual(0.5);
+    });
+
+    it('returns 1.249773510228908 if 386 is provided', () => {
+        expect(Utils.centsToRatio(386)).toEqual(1.249773510228908);
+    });
+})
+
+
+
 describe('Xentonality.Utils.setharesLoudness', () => {
-    it('returns 0 if 0 amplitude is provided', () => {
+    it('returns 0 if 0 amplitude is provided ', () => {
         expect(Utils.setharesLoudness(0)).toEqual(0);
     });
 
     // WARNING: double check the formula from Sethares
-    it('returns 0 if 0 amplitude is provided', () => {
+    it('returns 78.84951607609639 if 1 amplitude is provided ', () => {
         expect(Utils.setharesLoudness(1)).toEqual(78.84951607609639);
     });
 })
@@ -22,6 +69,10 @@ describe('Xentonality.Utils.getAmplitude', () => {
 
     it('returns 0.2 for ratio 5 and harmonic profile', () => {
         expect(Utils.getAmplitude("harmonic", 5)).toEqual(0.2);
+    });
+
+    it('returns 0.3333333333333333 for ratio 3 and harmonic profile', () => {
+        expect(Utils.getAmplitude("harmonic", 3)).toEqual(0.3333333333333333);
     });
 
     it('returns 1 for ratio 5 and equal profile', () => {


### PR DESCRIPTION
1. Adds missing tests
2. Does not add partial to spectrum if partial with same frequency already exists
3. EDO spectrum amplitudes are `1 / ratio` rather than `1 / index`