### PR TITLE
Resume Audio Context When Generating Sample

### DIFF
--- a/src/xentonality/dissonance.ts
+++ b/src/xentonality/dissonance.ts
@@ -44,7 +44,7 @@ export const calcDissonanceCurve = ({ partials, numberOfPoints, sweepStep, start
         const sweepPartials = changeFundamental({ partials: partials, fundamental: currentStep.Hz })
         const combinedPartials = combinePartials(partials, sweepPartials)
         const dissonanceValue = intrinsicDissonance(combinedPartials)
-        console.log(partials)
+
         const dissonancePoint = { ...currentStep, value: dissonanceValue, } as TPlotPoint
         dissonanceCurve.push(dissonancePoint)
     }

--- a/src/xentonality/synth.ts
+++ b/src/xentonality/synth.ts
@@ -111,8 +111,7 @@ export class AdditiveSynth {
             const audioBuffer: AudioBuffer = new AudioBuffer({ length, numberOfChannels: 1, sampleRate: this.sampleRate });
             const channelData = audioBuffer.getChannelData(0);
             const oscillatorPhases = this.oscillators.map(oscillator => randomPhase ? oscillator.phase : 0)
-            console.log(this.masterGain.gain.value)
-            console.log(this.oscillators.map(osc => osc.amplitude))
+
             for (let p = 0; p < length; p++) {
                 for (let i = 0; i < this.oscillators.length; i++) {
                     const omega = 2 * Math.PI * this.oscillators[i].frequency;

--- a/src/xentonality/synth.ts
+++ b/src/xentonality/synth.ts
@@ -104,12 +104,15 @@ export class AdditiveSynth {
     }
 
     public async generateSample(duration: number, randomPhase = false): Promise<AudioBuffer> {
+        if (this.audioContext.state !== 'running') await this.audioContext.resume()
+        
         const sample = new Promise<AudioBuffer>((resolve) => {
             const length = duration * this.sampleRate;
             const audioBuffer: AudioBuffer = new AudioBuffer({ length, numberOfChannels: 1, sampleRate: this.sampleRate });
             const channelData = audioBuffer.getChannelData(0);
             const oscillatorPhases = this.oscillators.map(oscillator => randomPhase ? oscillator.phase : 0)
-
+            console.log(this.masterGain.gain.value)
+            console.log(this.oscillators.map(osc => osc.amplitude))
             for (let p = 0; p < length; p++) {
                 for (let i = 0; i < this.oscillators.length; i++) {
                     const omega = 2 * Math.PI * this.oscillators[i].frequency;

--- a/test/unit/xentonality.dissonance.test.ts
+++ b/test/unit/xentonality.dissonance.test.ts
@@ -57,9 +57,8 @@ describe('Xentonality.Dissonance.calcDissonanceCurveMultipleOctaves', () => {
     // WARNING: I assume fixtures are correct, but need manual testing to confirm that
     it('returns diss curve for single partial', () => {
         const testFunction = Dissonance.calcDissonanceCurveMultipleOctaves({ partials: Factory.partials({ ratios: [1], fundamental: 440 }), octaves: [0, 1], points: 10 }).curve
-        console.log(testFunction)
+
         const expectedFunction = diss_curve_440_1_partial
-        console.log(expectedFunction)
 
         expect(curvesEqual(testFunction, expectedFunction)).toEqual(true);
     })


### PR DESCRIPTION
- removes console logs
- if exporting sample before playing synth, audio ctx was suspended and master gain value was returned = 1 causing clipping. Fixes by resumes audio context in generateSample method if it is suspended